### PR TITLE
Explicit import of the debug component

### DIFF
--- a/tests/dummy/app/components/rdfa-editor-with-debug.js
+++ b/tests/dummy/app/components/rdfa-editor-with-debug.js
@@ -1,0 +1,1 @@
+export { default } from '@lblod/ember-rdfa-editor/components/rdfa/rdfa-editor-with-debug';

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,6 @@
 {{page-title "besluit-plugin"}}
 
-<Rdfa::RdfaEditorWithDebug 
+<RdfaEditorWithDebug 
   @rdfaEditorInit={{this.rdfaEditorInit}}
   @plugins={{this.plugins}}
   @editorOptions={{hash    
@@ -19,4 +19,4 @@
     showIndentButtons="true"
   }}> 
   <h1>Dummy app - besluit-plugin</h1>
-</Rdfa::RdfaEditorWithDebug>
+</RdfaEditorWithDebug>


### PR DESCRIPTION
Due to the export of the debug component in the editor, the consuming app also imports modules only related to the debug component for no reason. The solution was to not export the debug component. The plugins that want to use the debug component need to explicitly import it first. This PR does that. Explicit importing is needed for ember-rdfa-editor v0.50.0-beta.8 and onward, but the explicit import won't break on older editor versions.