### PR TITLE
Bump editor to 0.63.1

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,10 +7,6 @@ module.exports = function (defaults) {
     // Add options here
     sassOptions: {
       sourceMapEmbed: true,
-      includePaths: [
-        'node_modules/@appuniversum/appuniversum',
-        'node_modules/@appuniversum/ember-appuniversum/app/styles',
-      ],
     },
   });
   /*

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,14 +18,11 @@
       },
       "devDependencies": {
         "@appuniversum/ember-appuniversum": "^1.5.0",
-        "@codemirror/basic-setup": ">=0.19.0",
-        "@codemirror/lang-html": ">=0.19.3",
-        "@codemirror/lang-xml": ">=0.19.2",
         "@ember/optional-features": "^2.0.0",
         "@ember/test-helpers": "^2.6.0",
         "@glimmer/component": "^1.0.3",
         "@glimmer/tracking": "^1.0.3",
-        "@lblod/ember-rdfa-editor": ">=0.62.1",
+        "@lblod/ember-rdfa-editor": ">=0.63.1",
         "babel-eslint": "^10.1.0",
         "broccoli-asset-rev": "^3.0.0",
         "ember-cli": "~3.28.5",
@@ -63,15 +60,14 @@
         "qunit": "^2.17.2",
         "qunit-dom": "^1.6.0",
         "sass": "^1.49.8",
-        "webpack": "^5.69.1",
-        "xml-formatter": "^2.6.1"
+        "webpack": "^5.69.1"
       },
       "engines": {
         "node": "14.* || >= 16"
       },
       "peerDependencies": {
         "@appuniversum/ember-appuniversum": "^1.5.0",
-        "@lblod/ember-rdfa-editor": ">=0.62.1",
+        "@lblod/ember-rdfa-editor": ">=0.63.1",
         "ember-concurrency": "^2.2.0",
         "ember-power-select": "^5.0.4"
       }
@@ -1788,317 +1784,141 @@
       }
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "0.19.15",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.15.tgz",
-      "integrity": "sha512-GQWzvvuXxNUyaEk+5gawbAD8s51/v2Chb++nx0e2eGWrphWk42isBtzOMdc3DxrxrZtPZ55q2ldNp+6G8KJLIQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.1.0.tgz",
+      "integrity": "sha512-wtO4O5WDyXhhCd4q4utDIDZxnQfmJ++3dGBCG9LMtI79+92OcA1DVk/n7BEupKmjIr8AzvptDz7YQ9ud6OkU+A==",
       "dev": true,
       "dependencies": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.4",
-        "@codemirror/text": "^0.19.2",
-        "@codemirror/tooltip": "^0.19.12",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "node_modules/@codemirror/basic-setup": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.19.3.tgz",
-      "integrity": "sha512-2hfO+QDk/HTpQzeYk1NyL1G9D5L7Sj78dtaQP8xBU42DKU9+OBPF5MdjLYnxP0jKzm6IfQfsLd89fnqW3rBVfQ==",
-      "deprecated": "In version 6.0, this package has been renamed to just 'codemirror'",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/autocomplete": "^0.19.0",
-        "@codemirror/closebrackets": "^0.19.0",
-        "@codemirror/commands": "^0.19.0",
-        "@codemirror/comment": "^0.19.0",
-        "@codemirror/fold": "^0.19.0",
-        "@codemirror/gutter": "^0.19.0",
-        "@codemirror/highlight": "^0.19.0",
-        "@codemirror/history": "^0.19.0",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/lint": "^0.19.0",
-        "@codemirror/matchbrackets": "^0.19.0",
-        "@codemirror/rectangular-selection": "^0.19.2",
-        "@codemirror/search": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.31"
-      }
-    },
-    "node_modules/@codemirror/closebrackets": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.2.tgz",
-      "integrity": "sha512-ClMPzPcPP0eQiDcVjtVPl6OLxgdtZSYDazsvT0AKl70V1OJva0eHgl4/6kCW3RZ0pb2n34i9nJz4eXCmK+TYDA==",
-      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/autocomplete",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.2",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.44"
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@codemirror/commands": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.8.tgz",
-      "integrity": "sha512-65LIMSGUGGpY3oH6mzV46YWRrgao6NmfJ+AuC7jNz3K5NPnH6GCV1H5I6SwOFyVbkiygGyd0EFwrWqywTBD1aw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.1.0.tgz",
+      "integrity": "sha512-qCj2YqmbBjj0P1iumnlL5lBqZvJPzT+t2UvgjcaXErp5ZvMqFRVgQyrEfdXX6SX5UcvcHKBjXqno+MkUp0aYvQ==",
       "dev": true,
       "dependencies": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/matchbrackets": "^0.19.0",
-        "@codemirror/state": "^0.19.2",
-        "@codemirror/text": "^0.19.6",
-        "@codemirror/view": "^0.19.22",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "node_modules/@codemirror/comment": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.1.tgz",
-      "integrity": "sha512-uGKteBuVWAC6fW+Yt8u27DOnXMT/xV4Ekk2Z5mRsiADCZDqYvryrJd6PLL5+8t64BVyocwQwNfz1UswYS2CtFQ==",
-      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/commands",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/state": "^0.19.9",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
-    "node_modules/@codemirror/fold": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.4.tgz",
-      "integrity": "sha512-0SNSkRSOa6gymD6GauHa3sxiysjPhUC0SRVyTlvL52o0gz9GHdc8kNqNQskm3fBtGGOiSriGwF/kAsajRiGhVw==",
-      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/language",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/gutter": "^0.19.0",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.22"
-      }
-    },
-    "node_modules/@codemirror/gutter": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.9.tgz",
-      "integrity": "sha512-PFrtmilahin1g6uL27aG5tM/rqR9DZzZYZsIrCXA5Uc2OFTFqx4owuhoU9hqfYxHp5ovfvBwQ+txFzqS4vog6Q==",
-      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/view",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.23"
-      }
-    },
-    "node_modules/@codemirror/highlight": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.8.tgz",
-      "integrity": "sha512-v/lzuHjrYR8MN2mEJcUD6fHSTXXli9C1XGYpr+ElV6fLBIUhMTNKR3qThp611xuWfXfwDxeL7ppcbkM/MzPV3A==",
-      "deprecated": "As of 0.20.0, this package has been split between @lezer/highlight and @codemirror/language",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.3",
-        "@codemirror/view": "^0.19.39",
-        "@lezer/common": "^0.15.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/@codemirror/history": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.2.tgz",
-      "integrity": "sha512-unhP4t3N2smzmHoo/Yio6ueWi+il8gm9VKrvi6wlcdGH5fOfVDNkmjHQ495SiR+EdOG35+3iNebSPYww0vN7ow==",
-      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/commands",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/state": "^0.19.2",
-        "@codemirror/view": "^0.19.0"
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@codemirror/lang-css": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-0.19.3.tgz",
-      "integrity": "sha512-tyCUJR42/UlfOPLb94/p7dN+IPsYSIzHbAHP2KQHANj0I+Orqp+IyIOS++M8TuCX4zkWh9dvi8s92yy/Tn8Ifg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.0.0.tgz",
+      "integrity": "sha512-jBqc+BTuwhNOTlrimFghLlSrN6iFuE44HULKWoR4qKYObhOIl9Lci1iYj6zMIte1XTQmZguNvjXMyr43LUKwSw==",
       "dev": true,
       "dependencies": {
-        "@codemirror/autocomplete": "^0.19.0",
-        "@codemirror/highlight": "^0.19.6",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@lezer/css": "^0.15.2"
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/css": "^1.0.0"
       }
     },
     "node_modules/@codemirror/lang-html": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.4.tgz",
-      "integrity": "sha512-GpiEikNuCBeFnS+/TJSeanwqaOfNm8Kkp9WpVNEPZCLyW1mAMCuFJu/3xlWYeWc778Hc3vJqGn3bn+cLNubgCA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.1.1.tgz",
+      "integrity": "sha512-+hV1kVZySmr7GxCgSVM+BodaVlsgD98laEJbj/GALhgIrfnHTSiRuTz2EPTjNCKeq5uEQXeOKFY711/CxJbYrg==",
       "dev": true,
       "dependencies": {
-        "@codemirror/autocomplete": "^0.19.0",
-        "@codemirror/highlight": "^0.19.6",
-        "@codemirror/lang-css": "^0.19.0",
-        "@codemirror/lang-javascript": "^0.19.0",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@lezer/common": "^0.15.0",
-        "@lezer/html": "^0.15.0"
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.2.2",
+        "@lezer/common": "^1.0.0",
+        "@lezer/html": "^1.0.1"
       }
     },
     "node_modules/@codemirror/lang-javascript": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.7.tgz",
-      "integrity": "sha512-DL9f3JLqOEHH9cIwEqqjnP5bkjdVXeECksLtV+/MbPm+l4H+AG+PkwZaJQ2oR1GfPZKh8MVSIE94aGWNkJP8WQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.0.2.tgz",
+      "integrity": "sha512-BZRJ9u/zl16hLkSpDAWm73mrfIR7HJrr0lvnhoSOCQVea5BglguWI/slxexhvUb0CB5cXgKWuo2bM+N9EhIaZw==",
       "dev": true,
       "dependencies": {
-        "@codemirror/autocomplete": "^0.19.0",
-        "@codemirror/highlight": "^0.19.7",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/lint": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/javascript": "^0.15.1"
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
       }
     },
     "node_modules/@codemirror/lang-xml": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-0.19.2.tgz",
-      "integrity": "sha512-9VIjxvqcH1sk8bmYbxQon0lXhVZgdHdfjGes+e4Akgvb43aMBDNvIQVALwrCb+XMEHTxLUMQtrsBN0G64yCUXw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.0.0.tgz",
+      "integrity": "sha512-M/HLWxIiP956xGjtrxkeHkCmDGVQGKu782x8pOH5CLJIMkWtiB1DWfDoDHqpFjdEE9dkfcqPWvYfVi6GbhuXEg==",
       "dev": true,
       "dependencies": {
-        "@codemirror/autocomplete": "^0.19.0",
-        "@codemirror/highlight": "^0.19.6",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@lezer/common": "^0.15.0",
-        "@lezer/xml": "^0.15.0"
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
       }
     },
     "node_modules/@codemirror/language": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.10.tgz",
-      "integrity": "sha512-yA0DZ3RYn2CqAAGW62VrU8c4YxscMQn45y/I9sjBlqB1e2OTQLg4CCkMBuMSLXk4xaqjlsgazeOQWaJQOKfV8Q==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.1.tgz",
+      "integrity": "sha512-MC3svxuvIj0MRpFlGHxLS6vPyIdbTr2KKPEW46kCoCXw2ktb4NTkpkPBI/lSP/FoNXLCBJ0mrnUi1OoZxtpW1Q==",
       "dev": true,
       "dependencies": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.5",
-        "@lezer/lr": "^0.15.0"
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
       }
     },
     "node_modules/@codemirror/lint": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.6.tgz",
-      "integrity": "sha512-Pbw1Y5kHVs2J+itQ0uez3dI4qY9ApYVap7eNfV81x1/3/BXgBkKfadaw0gqJ4h4FDG7OnJwb0VbPsjJQllHjaA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.0.0.tgz",
+      "integrity": "sha512-nUUXcJW1Xp54kNs+a1ToPLK8MadO0rMTnJB8Zk4Z8gBdrN0kqV7uvUraU/T2yqg+grDNR38Vmy/MrhQN/RgwiA==",
       "dev": true,
       "dependencies": {
-        "@codemirror/gutter": "^0.19.4",
-        "@codemirror/panel": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.1",
-        "@codemirror/state": "^0.19.4",
-        "@codemirror/tooltip": "^0.19.16",
-        "@codemirror/view": "^0.19.22",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
         "crelt": "^1.0.5"
       }
     },
-    "node_modules/@codemirror/matchbrackets": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.19.4.tgz",
-      "integrity": "sha512-VFkaOKPNudAA5sGP1zikRHCEKU0hjYmkKpr04pybUpQvfTvNJXlReCyP0rvH/1iEwAGPL990ZTT+QrLdu4MeEA==",
-      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/language",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "node_modules/@codemirror/panel": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.1.tgz",
-      "integrity": "sha512-sYeOCMA3KRYxZYJYn5PNlt9yNsjy3zTNTrbYSfVgjgL9QomIVgOJWPO5hZ2sTN8lufO6lw0vTBsIPL9MSidmBg==",
-      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/view",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
-    "node_modules/@codemirror/rangeset": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.9.tgz",
-      "integrity": "sha512-V8YUuOvK+ew87Xem+71nKcqu1SXd5QROMRLMS/ljT5/3MCxtgrRie1Cvild0G/Z2f1fpWxzX78V0U4jjXBorBQ==",
-      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/state",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/state": "^0.19.0"
-      }
-    },
-    "node_modules/@codemirror/rectangular-selection": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.19.2.tgz",
-      "integrity": "sha512-AXK/p5eGwFJ9GJcLfntqN4dgY+XiIF7eHfXNQJX5HhQLSped2wJE6WuC1rMEaOlcpOqlb9mrNi/ZdUjSIj9mbA==",
-      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/view",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.4",
-        "@codemirror/view": "^0.19.48"
-      }
-    },
     "node_modules/@codemirror/search": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.10.tgz",
-      "integrity": "sha512-qjubm69HJixPBWzI6HeEghTWOOD8NXiHOTRNvdizqs8xWRuFChq9zkjD3XiAJ7GXSTzCuQJnAP9DBBGCLq4ZIA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.2.0.tgz",
+      "integrity": "sha512-FVhpUvPFUJe8lg2EQJTTcF4RNI9d/OC3PVitvOfhv5OuY7ZgtMfJl22o5eMkzOEsUY2Wxe7BKGLpe2UI5Wq3PQ==",
       "dev": true,
       "dependencies": {
-        "@codemirror/panel": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.3",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.34",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
         "crelt": "^1.0.5"
       }
     },
     "node_modules/@codemirror/state": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
-      "integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/text": "^0.19.0"
-      }
-    },
-    "node_modules/@codemirror/text": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
-      "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA==",
-      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/state",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.1.tgz",
+      "integrity": "sha512-2s+aXsxmAwnR3Rd+JDHPG/1lw0YsA9PEwl7Re88gHJHGfxyfEzKBmsN4rr53RyPIR4lzbbhJX0DCq0WlqlBIRw==",
       "dev": true
     },
-    "node_modules/@codemirror/tooltip": {
-      "version": "0.19.16",
-      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.16.tgz",
-      "integrity": "sha512-zxKDHryUV5/RS45AQL+wOeN+i7/l81wK56OMnUPoTSzCWNITfxHn7BToDsjtrRKbzHqUxKYmBnn/4hPjpZ4WJQ==",
-      "deprecated": "As of 0.20.0, this package has been merged into @codemirror/view",
-      "dev": true,
-      "dependencies": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
     "node_modules/@codemirror/view": {
-      "version": "0.19.48",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.48.tgz",
-      "integrity": "sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==",
+      "version": "6.2.2",
+      "resolved": "git+ssh://git@github.com/codemirror/view.git#ddac2d27f42839dc3d84f46ef8bc65d1a99c3140",
+      "integrity": "sha512-ZimlXGCXKuaFar5MuKpbPJIL+jO7zz2vpt8zX1d+fGZccYju7Ot9pCSLw4y65uqTGv8zQI0hdD/bcDnBSGB0yw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@codemirror/rangeset": "^0.19.5",
-        "@codemirror/state": "^0.19.3",
-        "@codemirror/text": "^0.19.0",
+        "@codemirror/state": "^6.0.0",
         "style-mod": "^4.0.0",
         "w3c-keyname": "^2.2.4"
       }
@@ -3017,17 +2837,22 @@
       }
     },
     "node_modules/@lblod/ember-rdfa-editor": {
-      "version": "0.62.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.62.1.tgz",
-      "integrity": "sha512-oY5nrV7rQRomgr/NxN7mH1BAcFXxWENHtekpi0Ypr+Z1PIVgSIbdLXvFldGGpGctJ+46pB+N7hkNNnZDktvWig==",
+      "version": "0.63.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.63.1.tgz",
+      "integrity": "sha512-s51CSJcdE0xlImI+PQsDBLSIyTpOJP3pE3yed5lfoT1+UkGtGFi2TtkRqUjzrCdlk/pHz/GG/X+nT1JgGeyLtw==",
       "dev": true,
       "dependencies": {
+        "@codemirror/lang-html": "^6.1.1",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/view": "github:codemirror/view#ddac2d27f42839dc3d84f46ef8bc65d1a99c3140",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
         "@glimmer/tracking": "^1.0.4",
         "@graphy/memory.dataset.fast": "4.3.3",
         "@lblod/marawa": "^0.8.0-beta.2",
         "@types/diff-match-patch": "^1.0.32",
+        "codemirror": "^6.0.1",
         "common-tags": "^1.8.0",
         "crypto-browserify": "^3.12.0",
         "debug": "^4.3.4",
@@ -3035,7 +2860,7 @@
         "dompurify": "^2.3.6",
         "ember-auto-import": "^2.4.1",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^5.7.2",
+        "ember-cli-htmlbars": "^6.1.0",
         "ember-cli-typescript": "^5.1.0",
         "ember-concurrency": "^2.2.1",
         "ember-concurrency-ts": "^0.3.1",
@@ -3053,76 +2878,14 @@
         "rdf-data-factory": "^1.1.0",
         "relative-to-absolute-iri": "^1.0.6",
         "stream-browserify": "^3.0.0",
-        "tracked-built-ins": "^2.0.1"
+        "tracked-built-ins": "^2.0.1",
+        "xml-formatter": "^2.6.1"
       },
       "engines": {
         "node": "14.* || >= 16"
       },
       "peerDependencies": {
-        "@appuniversum/ember-appuniversum": "^1.0.7",
-        "@codemirror/basic-setup": ">=0.19.0",
-        "@codemirror/lang-html": ">=0.19.4",
-        "@codemirror/lang-xml": ">=0.19.2",
-        "xml-formatter": "^2.4.0"
-      },
-      "peerDependenciesMeta": {
-        "@codemirror/basic-setup": {
-          "optional": true
-        },
-        "@codemirror/lang-html": {
-          "optional": true
-        },
-        "@codemirror/lang-xml": {
-          "optional": true
-        },
-        "xml-formatter": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor/node_modules/broccoli-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-      "dev": true,
-      "dependencies": {
-        "broccoli-node-api": "^1.7.0",
-        "broccoli-output-wrapper": "^3.2.5",
-        "fs-merger": "^3.2.1",
-        "promise-map-series": "^0.3.0",
-        "quick-temp": "^0.1.8",
-        "rimraf": "^3.0.2",
-        "symlink-or-copy": "^1.3.1"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor/node_modules/ember-cli-htmlbars": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-      "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-      "dev": true,
-      "dependencies": {
-        "@ember/edition-utils": "^1.2.0",
-        "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-        "broccoli-debug": "^0.6.5",
-        "broccoli-persistent-filter": "^3.1.2",
-        "broccoli-plugin": "^4.0.3",
-        "common-tags": "^1.8.0",
-        "ember-cli-babel-plugin-helpers": "^1.1.1",
-        "ember-cli-version-checker": "^5.1.2",
-        "fs-tree-diff": "^2.0.1",
-        "hash-for-dep": "^1.5.1",
-        "heimdalljs-logger": "^0.1.10",
-        "json-stable-stringify": "^1.0.1",
-        "semver": "^7.3.4",
-        "silent-error": "^1.1.1",
-        "strip-bom": "^4.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
+        "@appuniversum/ember-appuniversum": "^1.5.0"
       }
     },
     "node_modules/@lblod/ember-rdfa-editor/node_modules/ember-cli-typescript": {
@@ -3174,31 +2937,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@lblod/ember-rdfa-editor/node_modules/fs-tree-diff": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-      "dev": true,
-      "dependencies": {
-        "@types/symlink-or-copy": "^1.2.0",
-        "heimdalljs-logger": "^0.1.7",
-        "object-assign": "^4.1.0",
-        "path-posix": "^1.0.0",
-        "symlink-or-copy": "^1.1.8"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor/node_modules/promise-map-series": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-      "dev": true,
-      "engines": {
-        "node": "10.* || >= 12.*"
-      }
-    },
     "node_modules/@lblod/ember-rdfa-editor/node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -3211,21 +2949,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/@lblod/ember-rdfa-editor/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@lblod/ember-rdfa-editor/node_modules/rsvp": {
@@ -3273,54 +2996,68 @@
       }
     },
     "node_modules/@lezer/common": {
-      "version": "0.15.12",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
-      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.1.tgz",
+      "integrity": "sha512-8TR5++Q/F//tpDsLd5zkrvEX5xxeemafEaek7mUp7Y+bI8cKQXdSqhzTOBaOogETcMOVr0pT3BBPXp13477ciw==",
       "dev": true
     },
     "node_modules/@lezer/css": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-0.15.2.tgz",
-      "integrity": "sha512-tnMOMZY0Zs6JQeVjqfmREYMV0GnmZR1NitndLWioZMD6mA7VQF/PPKPmJX1f+ZgVZQc5Am0df9mX3aiJnNJlKQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.0.0.tgz",
+      "integrity": "sha512-616VqgDKumHmYIuxs3tnX1irEQmoDHgF/TlP4O5ICWwyHwLMErq+8iKVuzTkOdBqvYAVmObqThcDEAaaMJjAdg==",
       "dev": true,
       "dependencies": {
-        "@lezer/lr": "^0.15.0"
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.0.0.tgz",
+      "integrity": "sha512-nsCnNtim90UKsB5YxoX65v3GEIw3iCHw9RM2DtdgkiqAbKh9pCdvi8AWNwkYf10Lu6fxNhXPpkpHbW6mihhvJA==",
+      "dev": true,
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@lezer/html": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-0.15.1.tgz",
-      "integrity": "sha512-0ZYVhu+RwN6ZMM0gNnTxenRAdoycKc2wvpLfMjP0JkKR0vMxhtuLaIpsq9KW2Mv6l7ux5vdjq8CQ7fKDvia8KA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.0.1.tgz",
+      "integrity": "sha512-sC00zEt3GBh3vVO6QaGX4YZCl41S9dHWN/WGBsDixy9G+sqOC7gsa4cxA/fmRVAiBvhqYkJk+5Ul4oul92CPVw==",
       "dev": true,
       "dependencies": {
-        "@lezer/lr": "^0.15.0"
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/javascript": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-0.15.3.tgz",
-      "integrity": "sha512-8jA2NpOfpWwSPZxRhd9BxK2ZPvGd7nLE3LFTJ5AbMhXAzMHeMjneV6GEVd7dAIee85dtap0jdb6bgOSO0+lfwA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.0.2.tgz",
+      "integrity": "sha512-IjOVeIRhM8IuafWNnk+UzRz7p4/JSOKBNINLYLsdSGuJS9Ju7vFdc82AlTt0jgtV5D8eBZf4g0vK4d3ttBNz7A==",
       "dev": true,
       "dependencies": {
-        "@lezer/lr": "^0.15.0"
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@lezer/lr": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
-      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.2.3.tgz",
+      "integrity": "sha512-qpB7rBzH8f6Mzjv2AVZRahcm+2Cf7nbIH++uXbvVOL1yIRvVWQ3HAM/saeBLCyz/togB7LGo76qdJYL1uKQlqA==",
       "dev": true,
       "dependencies": {
-        "@lezer/common": "^0.15.0"
+        "@lezer/common": "^1.0.0"
       }
     },
     "node_modules/@lezer/xml": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-0.15.1.tgz",
-      "integrity": "sha512-vVh01enxM9hSGOcFtztmX+Pa460HDq5jIeft9bDCe17PUOU0nAbfo883I3cW9lUOcmWNQ3btbkmXMGjRszJE6g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.0.tgz",
+      "integrity": "sha512-73iI9UK8iqSvWtLlOEl/g+50ivwQn8Ge6foHVN66AXUS1RccFnAoc7BYU8b3c8/rP6dfCOGqAGaWLxBzhj60MA==",
       "dev": true,
       "dependencies": {
-        "@lezer/lr": "^0.15.0"
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "node_modules/@mrmlnc/readdir-enhanced": {
@@ -8324,6 +8061,21 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/codemirror": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+      "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+      "dev": true,
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
       }
     },
     "node_modules/collection-visit": {
@@ -32737,9 +32489,9 @@
       "dev": true
     },
     "node_modules/w3c-keyname": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
-      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
+      "integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==",
       "dev": true
     },
     "node_modules/walk-sync": {
@@ -34851,304 +34603,134 @@
       }
     },
     "@codemirror/autocomplete": {
-      "version": "0.19.15",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-0.19.15.tgz",
-      "integrity": "sha512-GQWzvvuXxNUyaEk+5gawbAD8s51/v2Chb++nx0e2eGWrphWk42isBtzOMdc3DxrxrZtPZ55q2ldNp+6G8KJLIQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.1.0.tgz",
+      "integrity": "sha512-wtO4O5WDyXhhCd4q4utDIDZxnQfmJ++3dGBCG9LMtI79+92OcA1DVk/n7BEupKmjIr8AzvptDz7YQ9ud6OkU+A==",
       "dev": true,
       "requires": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.4",
-        "@codemirror/text": "^0.19.2",
-        "@codemirror/tooltip": "^0.19.12",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "@codemirror/basic-setup": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/basic-setup/-/basic-setup-0.19.3.tgz",
-      "integrity": "sha512-2hfO+QDk/HTpQzeYk1NyL1G9D5L7Sj78dtaQP8xBU42DKU9+OBPF5MdjLYnxP0jKzm6IfQfsLd89fnqW3rBVfQ==",
-      "dev": true,
-      "requires": {
-        "@codemirror/autocomplete": "^0.19.0",
-        "@codemirror/closebrackets": "^0.19.0",
-        "@codemirror/commands": "^0.19.0",
-        "@codemirror/comment": "^0.19.0",
-        "@codemirror/fold": "^0.19.0",
-        "@codemirror/gutter": "^0.19.0",
-        "@codemirror/highlight": "^0.19.0",
-        "@codemirror/history": "^0.19.0",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/lint": "^0.19.0",
-        "@codemirror/matchbrackets": "^0.19.0",
-        "@codemirror/rectangular-selection": "^0.19.2",
-        "@codemirror/search": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.31"
-      }
-    },
-    "@codemirror/closebrackets": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/closebrackets/-/closebrackets-0.19.2.tgz",
-      "integrity": "sha512-ClMPzPcPP0eQiDcVjtVPl6OLxgdtZSYDazsvT0AKl70V1OJva0eHgl4/6kCW3RZ0pb2n34i9nJz4eXCmK+TYDA==",
-      "dev": true,
-      "requires": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.2",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.44"
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
       }
     },
     "@codemirror/commands": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-0.19.8.tgz",
-      "integrity": "sha512-65LIMSGUGGpY3oH6mzV46YWRrgao6NmfJ+AuC7jNz3K5NPnH6GCV1H5I6SwOFyVbkiygGyd0EFwrWqywTBD1aw==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.1.0.tgz",
+      "integrity": "sha512-qCj2YqmbBjj0P1iumnlL5lBqZvJPzT+t2UvgjcaXErp5ZvMqFRVgQyrEfdXX6SX5UcvcHKBjXqno+MkUp0aYvQ==",
       "dev": true,
       "requires": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/matchbrackets": "^0.19.0",
-        "@codemirror/state": "^0.19.2",
-        "@codemirror/text": "^0.19.6",
-        "@codemirror/view": "^0.19.22",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "@codemirror/comment": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/comment/-/comment-0.19.1.tgz",
-      "integrity": "sha512-uGKteBuVWAC6fW+Yt8u27DOnXMT/xV4Ekk2Z5mRsiADCZDqYvryrJd6PLL5+8t64BVyocwQwNfz1UswYS2CtFQ==",
-      "dev": true,
-      "requires": {
-        "@codemirror/state": "^0.19.9",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
-    "@codemirror/fold": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/fold/-/fold-0.19.4.tgz",
-      "integrity": "sha512-0SNSkRSOa6gymD6GauHa3sxiysjPhUC0SRVyTlvL52o0gz9GHdc8kNqNQskm3fBtGGOiSriGwF/kAsajRiGhVw==",
-      "dev": true,
-      "requires": {
-        "@codemirror/gutter": "^0.19.0",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.22"
-      }
-    },
-    "@codemirror/gutter": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@codemirror/gutter/-/gutter-0.19.9.tgz",
-      "integrity": "sha512-PFrtmilahin1g6uL27aG5tM/rqR9DZzZYZsIrCXA5Uc2OFTFqx4owuhoU9hqfYxHp5ovfvBwQ+txFzqS4vog6Q==",
-      "dev": true,
-      "requires": {
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.23"
-      }
-    },
-    "@codemirror/highlight": {
-      "version": "0.19.8",
-      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.8.tgz",
-      "integrity": "sha512-v/lzuHjrYR8MN2mEJcUD6fHSTXXli9C1XGYpr+ElV6fLBIUhMTNKR3qThp611xuWfXfwDxeL7ppcbkM/MzPV3A==",
-      "dev": true,
-      "requires": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.3",
-        "@codemirror/view": "^0.19.39",
-        "@lezer/common": "^0.15.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "@codemirror/history": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/history/-/history-0.19.2.tgz",
-      "integrity": "sha512-unhP4t3N2smzmHoo/Yio6ueWi+il8gm9VKrvi6wlcdGH5fOfVDNkmjHQ495SiR+EdOG35+3iNebSPYww0vN7ow==",
-      "dev": true,
-      "requires": {
-        "@codemirror/state": "^0.19.2",
-        "@codemirror/view": "^0.19.0"
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0"
       }
     },
     "@codemirror/lang-css": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-0.19.3.tgz",
-      "integrity": "sha512-tyCUJR42/UlfOPLb94/p7dN+IPsYSIzHbAHP2KQHANj0I+Orqp+IyIOS++M8TuCX4zkWh9dvi8s92yy/Tn8Ifg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-css/-/lang-css-6.0.0.tgz",
+      "integrity": "sha512-jBqc+BTuwhNOTlrimFghLlSrN6iFuE44HULKWoR4qKYObhOIl9Lci1iYj6zMIte1XTQmZguNvjXMyr43LUKwSw==",
       "dev": true,
       "requires": {
-        "@codemirror/autocomplete": "^0.19.0",
-        "@codemirror/highlight": "^0.19.6",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@lezer/css": "^0.15.2"
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/css": "^1.0.0"
       }
     },
     "@codemirror/lang-html": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-0.19.4.tgz",
-      "integrity": "sha512-GpiEikNuCBeFnS+/TJSeanwqaOfNm8Kkp9WpVNEPZCLyW1mAMCuFJu/3xlWYeWc778Hc3vJqGn3bn+cLNubgCA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.1.1.tgz",
+      "integrity": "sha512-+hV1kVZySmr7GxCgSVM+BodaVlsgD98laEJbj/GALhgIrfnHTSiRuTz2EPTjNCKeq5uEQXeOKFY711/CxJbYrg==",
       "dev": true,
       "requires": {
-        "@codemirror/autocomplete": "^0.19.0",
-        "@codemirror/highlight": "^0.19.6",
-        "@codemirror/lang-css": "^0.19.0",
-        "@codemirror/lang-javascript": "^0.19.0",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@lezer/common": "^0.15.0",
-        "@lezer/html": "^0.15.0"
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/lang-css": "^6.0.0",
+        "@codemirror/lang-javascript": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.2.2",
+        "@lezer/common": "^1.0.0",
+        "@lezer/html": "^1.0.1"
       }
     },
     "@codemirror/lang-javascript": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-0.19.7.tgz",
-      "integrity": "sha512-DL9f3JLqOEHH9cIwEqqjnP5bkjdVXeECksLtV+/MbPm+l4H+AG+PkwZaJQ2oR1GfPZKh8MVSIE94aGWNkJP8WQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.0.2.tgz",
+      "integrity": "sha512-BZRJ9u/zl16hLkSpDAWm73mrfIR7HJrr0lvnhoSOCQVea5BglguWI/slxexhvUb0CB5cXgKWuo2bM+N9EhIaZw==",
       "dev": true,
       "requires": {
-        "@codemirror/autocomplete": "^0.19.0",
-        "@codemirror/highlight": "^0.19.7",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/lint": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/javascript": "^0.15.1"
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
       }
     },
     "@codemirror/lang-xml": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-0.19.2.tgz",
-      "integrity": "sha512-9VIjxvqcH1sk8bmYbxQon0lXhVZgdHdfjGes+e4Akgvb43aMBDNvIQVALwrCb+XMEHTxLUMQtrsBN0G64yCUXw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-xml/-/lang-xml-6.0.0.tgz",
+      "integrity": "sha512-M/HLWxIiP956xGjtrxkeHkCmDGVQGKu782x8pOH5CLJIMkWtiB1DWfDoDHqpFjdEE9dkfcqPWvYfVi6GbhuXEg==",
       "dev": true,
       "requires": {
-        "@codemirror/autocomplete": "^0.19.0",
-        "@codemirror/highlight": "^0.19.6",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@lezer/common": "^0.15.0",
-        "@lezer/xml": "^0.15.0"
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/xml": "^1.0.0"
       }
     },
     "@codemirror/language": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.10.tgz",
-      "integrity": "sha512-yA0DZ3RYn2CqAAGW62VrU8c4YxscMQn45y/I9sjBlqB1e2OTQLg4CCkMBuMSLXk4xaqjlsgazeOQWaJQOKfV8Q==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.2.1.tgz",
+      "integrity": "sha512-MC3svxuvIj0MRpFlGHxLS6vPyIdbTr2KKPEW46kCoCXw2ktb4NTkpkPBI/lSP/FoNXLCBJ0mrnUi1OoZxtpW1Q==",
       "dev": true,
       "requires": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.5",
-        "@lezer/lr": "^0.15.0"
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
       }
     },
     "@codemirror/lint": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-0.19.6.tgz",
-      "integrity": "sha512-Pbw1Y5kHVs2J+itQ0uez3dI4qY9ApYVap7eNfV81x1/3/BXgBkKfadaw0gqJ4h4FDG7OnJwb0VbPsjJQllHjaA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.0.0.tgz",
+      "integrity": "sha512-nUUXcJW1Xp54kNs+a1ToPLK8MadO0rMTnJB8Zk4Z8gBdrN0kqV7uvUraU/T2yqg+grDNR38Vmy/MrhQN/RgwiA==",
       "dev": true,
       "requires": {
-        "@codemirror/gutter": "^0.19.4",
-        "@codemirror/panel": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.1",
-        "@codemirror/state": "^0.19.4",
-        "@codemirror/tooltip": "^0.19.16",
-        "@codemirror/view": "^0.19.22",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
         "crelt": "^1.0.5"
       }
     },
-    "@codemirror/matchbrackets": {
-      "version": "0.19.4",
-      "resolved": "https://registry.npmjs.org/@codemirror/matchbrackets/-/matchbrackets-0.19.4.tgz",
-      "integrity": "sha512-VFkaOKPNudAA5sGP1zikRHCEKU0hjYmkKpr04pybUpQvfTvNJXlReCyP0rvH/1iEwAGPL990ZTT+QrLdu4MeEA==",
-      "dev": true,
-      "requires": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0"
-      }
-    },
-    "@codemirror/panel": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/panel/-/panel-0.19.1.tgz",
-      "integrity": "sha512-sYeOCMA3KRYxZYJYn5PNlt9yNsjy3zTNTrbYSfVgjgL9QomIVgOJWPO5hZ2sTN8lufO6lw0vTBsIPL9MSidmBg==",
-      "dev": true,
-      "requires": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
-    "@codemirror/rangeset": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.9.tgz",
-      "integrity": "sha512-V8YUuOvK+ew87Xem+71nKcqu1SXd5QROMRLMS/ljT5/3MCxtgrRie1Cvild0G/Z2f1fpWxzX78V0U4jjXBorBQ==",
-      "dev": true,
-      "requires": {
-        "@codemirror/state": "^0.19.0"
-      }
-    },
-    "@codemirror/rectangular-selection": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/rectangular-selection/-/rectangular-selection-0.19.2.tgz",
-      "integrity": "sha512-AXK/p5eGwFJ9GJcLfntqN4dgY+XiIF7eHfXNQJX5HhQLSped2wJE6WuC1rMEaOlcpOqlb9mrNi/ZdUjSIj9mbA==",
-      "dev": true,
-      "requires": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.4",
-        "@codemirror/view": "^0.19.48"
-      }
-    },
     "@codemirror/search": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-0.19.10.tgz",
-      "integrity": "sha512-qjubm69HJixPBWzI6HeEghTWOOD8NXiHOTRNvdizqs8xWRuFChq9zkjD3XiAJ7GXSTzCuQJnAP9DBBGCLq4ZIA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.2.0.tgz",
+      "integrity": "sha512-FVhpUvPFUJe8lg2EQJTTcF4RNI9d/OC3PVitvOfhv5OuY7ZgtMfJl22o5eMkzOEsUY2Wxe7BKGLpe2UI5Wq3PQ==",
       "dev": true,
       "requires": {
-        "@codemirror/panel": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.3",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.34",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
         "crelt": "^1.0.5"
       }
     },
     "@codemirror/state": {
-      "version": "0.19.9",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.9.tgz",
-      "integrity": "sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==",
-      "dev": true,
-      "requires": {
-        "@codemirror/text": "^0.19.0"
-      }
-    },
-    "@codemirror/text": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.6.tgz",
-      "integrity": "sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.1.1.tgz",
+      "integrity": "sha512-2s+aXsxmAwnR3Rd+JDHPG/1lw0YsA9PEwl7Re88gHJHGfxyfEzKBmsN4rr53RyPIR4lzbbhJX0DCq0WlqlBIRw==",
       "dev": true
     },
-    "@codemirror/tooltip": {
-      "version": "0.19.16",
-      "resolved": "https://registry.npmjs.org/@codemirror/tooltip/-/tooltip-0.19.16.tgz",
-      "integrity": "sha512-zxKDHryUV5/RS45AQL+wOeN+i7/l81wK56OMnUPoTSzCWNITfxHn7BToDsjtrRKbzHqUxKYmBnn/4hPjpZ4WJQ==",
-      "dev": true,
-      "requires": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0"
-      }
-    },
     "@codemirror/view": {
-      "version": "0.19.48",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.48.tgz",
-      "integrity": "sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==",
+      "version": "git+ssh://git@github.com/codemirror/view.git#ddac2d27f42839dc3d84f46ef8bc65d1a99c3140",
+      "integrity": "sha512-ZimlXGCXKuaFar5MuKpbPJIL+jO7zz2vpt8zX1d+fGZccYju7Ot9pCSLw4y65uqTGv8zQI0hdD/bcDnBSGB0yw==",
       "dev": true,
+      "from": "@codemirror/view@^6.0.0",
       "requires": {
-        "@codemirror/rangeset": "^0.19.5",
-        "@codemirror/state": "^0.19.3",
-        "@codemirror/text": "^0.19.0",
+        "@codemirror/state": "^6.0.0",
         "style-mod": "^4.0.0",
         "w3c-keyname": "^2.2.4"
       }
@@ -35931,17 +35513,22 @@
       }
     },
     "@lblod/ember-rdfa-editor": {
-      "version": "0.62.1",
-      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.62.1.tgz",
-      "integrity": "sha512-oY5nrV7rQRomgr/NxN7mH1BAcFXxWENHtekpi0Ypr+Z1PIVgSIbdLXvFldGGpGctJ+46pB+N7hkNNnZDktvWig==",
+      "version": "0.63.1",
+      "resolved": "https://registry.npmjs.org/@lblod/ember-rdfa-editor/-/ember-rdfa-editor-0.63.1.tgz",
+      "integrity": "sha512-s51CSJcdE0xlImI+PQsDBLSIyTpOJP3pE3yed5lfoT1+UkGtGFi2TtkRqUjzrCdlk/pHz/GG/X+nT1JgGeyLtw==",
       "dev": true,
       "requires": {
+        "@codemirror/lang-html": "^6.1.1",
+        "@codemirror/lang-xml": "^6.0.0",
+        "@codemirror/state": "^6.1.1",
+        "@codemirror/view": "github:codemirror/view#ddac2d27f42839dc3d84f46ef8bc65d1a99c3140",
         "@ember/optional-features": "^2.0.0",
         "@ember/render-modifiers": "^2.0.4",
         "@glimmer/tracking": "^1.0.4",
         "@graphy/memory.dataset.fast": "4.3.3",
         "@lblod/marawa": "^0.8.0-beta.2",
         "@types/diff-match-patch": "^1.0.32",
+        "codemirror": "^6.0.1",
         "common-tags": "^1.8.0",
         "crypto-browserify": "^3.12.0",
         "debug": "^4.3.4",
@@ -35949,7 +35536,7 @@
         "dompurify": "^2.3.6",
         "ember-auto-import": "^2.4.1",
         "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^5.7.2",
+        "ember-cli-htmlbars": "^6.1.0",
         "ember-cli-typescript": "^5.1.0",
         "ember-concurrency": "^2.2.1",
         "ember-concurrency-ts": "^0.3.1",
@@ -35967,48 +35554,10 @@
         "rdf-data-factory": "^1.1.0",
         "relative-to-absolute-iri": "^1.0.6",
         "stream-browserify": "^3.0.0",
-        "tracked-built-ins": "^2.0.1"
+        "tracked-built-ins": "^2.0.1",
+        "xml-formatter": "^2.6.1"
       },
       "dependencies": {
-        "broccoli-plugin": {
-          "version": "4.0.7",
-          "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
-          "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
-          "dev": true,
-          "requires": {
-            "broccoli-node-api": "^1.7.0",
-            "broccoli-output-wrapper": "^3.2.5",
-            "fs-merger": "^3.2.1",
-            "promise-map-series": "^0.3.0",
-            "quick-temp": "^0.1.8",
-            "rimraf": "^3.0.2",
-            "symlink-or-copy": "^1.3.1"
-          }
-        },
-        "ember-cli-htmlbars": {
-          "version": "5.7.2",
-          "resolved": "https://registry.npmjs.org/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz",
-          "integrity": "sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==",
-          "dev": true,
-          "requires": {
-            "@ember/edition-utils": "^1.2.0",
-            "babel-plugin-htmlbars-inline-precompile": "^5.0.0",
-            "broccoli-debug": "^0.6.5",
-            "broccoli-persistent-filter": "^3.1.2",
-            "broccoli-plugin": "^4.0.3",
-            "common-tags": "^1.8.0",
-            "ember-cli-babel-plugin-helpers": "^1.1.1",
-            "ember-cli-version-checker": "^5.1.2",
-            "fs-tree-diff": "^2.0.1",
-            "hash-for-dep": "^1.5.1",
-            "heimdalljs-logger": "^0.1.10",
-            "json-stable-stringify": "^1.0.1",
-            "semver": "^7.3.4",
-            "silent-error": "^1.1.1",
-            "strip-bom": "^4.0.0",
-            "walk-sync": "^2.2.0"
-          }
-        },
         "ember-cli-typescript": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.1.0.tgz",
@@ -36049,25 +35598,6 @@
             "universalify": "^2.0.0"
           }
         },
-        "fs-tree-diff": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
-          "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
-          "dev": true,
-          "requires": {
-            "@types/symlink-or-copy": "^1.2.0",
-            "heimdalljs-logger": "^0.1.7",
-            "object-assign": "^4.1.0",
-            "path-posix": "^1.0.0",
-            "symlink-or-copy": "^1.1.8"
-          }
-        },
-        "promise-map-series": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
-          "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
-          "dev": true
-        },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -36077,15 +35607,6 @@
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
             "util-deprecate": "^1.0.1"
-          }
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
           }
         },
         "rsvp": {
@@ -36129,54 +35650,68 @@
       }
     },
     "@lezer/common": {
-      "version": "0.15.12",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.12.tgz",
-      "integrity": "sha512-edfwCxNLnzq5pBA/yaIhwJ3U3Kz8VAUOTRg0hhxaizaI1N+qxV7EXDv/kLCkLeq2RzSFvxexlaj5Mzfn2kY0Ig==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.0.1.tgz",
+      "integrity": "sha512-8TR5++Q/F//tpDsLd5zkrvEX5xxeemafEaek7mUp7Y+bI8cKQXdSqhzTOBaOogETcMOVr0pT3BBPXp13477ciw==",
       "dev": true
     },
     "@lezer/css": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-0.15.2.tgz",
-      "integrity": "sha512-tnMOMZY0Zs6JQeVjqfmREYMV0GnmZR1NitndLWioZMD6mA7VQF/PPKPmJX1f+ZgVZQc5Am0df9mX3aiJnNJlKQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.0.0.tgz",
+      "integrity": "sha512-616VqgDKumHmYIuxs3tnX1irEQmoDHgF/TlP4O5ICWwyHwLMErq+8iKVuzTkOdBqvYAVmObqThcDEAaaMJjAdg==",
       "dev": true,
       "requires": {
-        "@lezer/lr": "^0.15.0"
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "@lezer/highlight": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.0.0.tgz",
+      "integrity": "sha512-nsCnNtim90UKsB5YxoX65v3GEIw3iCHw9RM2DtdgkiqAbKh9pCdvi8AWNwkYf10Lu6fxNhXPpkpHbW6mihhvJA==",
+      "dev": true,
+      "requires": {
+        "@lezer/common": "^1.0.0"
       }
     },
     "@lezer/html": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-0.15.1.tgz",
-      "integrity": "sha512-0ZYVhu+RwN6ZMM0gNnTxenRAdoycKc2wvpLfMjP0JkKR0vMxhtuLaIpsq9KW2Mv6l7ux5vdjq8CQ7fKDvia8KA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.0.1.tgz",
+      "integrity": "sha512-sC00zEt3GBh3vVO6QaGX4YZCl41S9dHWN/WGBsDixy9G+sqOC7gsa4cxA/fmRVAiBvhqYkJk+5Ul4oul92CPVw==",
       "dev": true,
       "requires": {
-        "@lezer/lr": "^0.15.0"
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "@lezer/javascript": {
-      "version": "0.15.3",
-      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-0.15.3.tgz",
-      "integrity": "sha512-8jA2NpOfpWwSPZxRhd9BxK2ZPvGd7nLE3LFTJ5AbMhXAzMHeMjneV6GEVd7dAIee85dtap0jdb6bgOSO0+lfwA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.0.2.tgz",
+      "integrity": "sha512-IjOVeIRhM8IuafWNnk+UzRz7p4/JSOKBNINLYLsdSGuJS9Ju7vFdc82AlTt0jgtV5D8eBZf4g0vK4d3ttBNz7A==",
       "dev": true,
       "requires": {
-        "@lezer/lr": "^0.15.0"
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "@lezer/lr": {
-      "version": "0.15.8",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.8.tgz",
-      "integrity": "sha512-bM6oE6VQZ6hIFxDNKk8bKPa14hqFrV07J/vHGOeiAbJReIaQXmkVb6xQu4MR+JBTLa5arGRyAAjJe1qaQt3Uvg==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.2.3.tgz",
+      "integrity": "sha512-qpB7rBzH8f6Mzjv2AVZRahcm+2Cf7nbIH++uXbvVOL1yIRvVWQ3HAM/saeBLCyz/togB7LGo76qdJYL1uKQlqA==",
       "dev": true,
       "requires": {
-        "@lezer/common": "^0.15.0"
+        "@lezer/common": "^1.0.0"
       }
     },
     "@lezer/xml": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-0.15.1.tgz",
-      "integrity": "sha512-vVh01enxM9hSGOcFtztmX+Pa460HDq5jIeft9bDCe17PUOU0nAbfo883I3cW9lUOcmWNQ3btbkmXMGjRszJE6g==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.0.tgz",
+      "integrity": "sha512-73iI9UK8iqSvWtLlOEl/g+50ivwQn8Ge6foHVN66AXUS1RccFnAoc7BYU8b3c8/rP6dfCOGqAGaWLxBzhj60MA==",
       "dev": true,
       "requires": {
-        "@lezer/lr": "^0.15.0"
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
       }
     },
     "@mrmlnc/readdir-enhanced": {
@@ -40366,6 +39901,21 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
       "dev": true
+    },
+    "codemirror": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
+      "integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+      "dev": true,
+      "requires": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -59794,9 +59344,9 @@
       "dev": true
     },
     "w3c-keyname": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
-      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.6.tgz",
+      "integrity": "sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==",
       "dev": true
     },
     "walk-sync": {

--- a/package.json
+++ b/package.json
@@ -35,20 +35,17 @@
   },
   "peerDependencies": {
     "@appuniversum/ember-appuniversum": "^1.5.0",
-    "@lblod/ember-rdfa-editor": ">=0.62.1",
+    "@lblod/ember-rdfa-editor": ">=0.63.1",
     "ember-concurrency": "^2.2.0",
     "ember-power-select": "^5.0.4"
   },
   "devDependencies": {
     "@appuniversum/ember-appuniversum": "^1.5.0",
-    "@codemirror/basic-setup": ">=0.19.0",
-    "@codemirror/lang-html": ">=0.19.3",
-    "@codemirror/lang-xml": ">=0.19.2",
     "@ember/optional-features": "^2.0.0",
     "@ember/test-helpers": "^2.6.0",
     "@glimmer/component": "^1.0.3",
     "@glimmer/tracking": "^1.0.3",
-    "@lblod/ember-rdfa-editor": ">=0.62.1",
+    "@lblod/ember-rdfa-editor": ">=0.63.1",
     "babel-eslint": "^10.1.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~3.28.5",
@@ -86,8 +83,7 @@
     "qunit": "^2.17.2",
     "qunit-dom": "^1.6.0",
     "sass": "^1.49.8",
-    "webpack": "^5.69.1",
-    "xml-formatter": "^2.6.1"
+    "webpack": "^5.69.1"
   },
   "engines": {
     "node": "14.* || >= 16"

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -2,4 +2,5 @@
    #DUMMY APP
    ================================== */
 
-@import 'ember-rdfa-editor/a-dummy';
+@import "ember-appuniversum";
+@import 'ember-rdfa-editor';


### PR DESCRIPTION
Includes changes to the way the sass is imported, and the removal of the codemirror deps for consuming apps